### PR TITLE
Generate a static site to allow deployment to Cloudflare Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a Next.js application generated with
 [Create Fumadocs](https://github.com/fuma-nama/fumadocs).
 
-Run development server:
+## Run Development Server
 
 ```bash
 npm run dev
@@ -15,12 +15,38 @@ yarn dev
 
 Open http://localhost:3000 with your browser to see the result.
 
+## Static Site Generation (SSG)
+
+This project is configured to generate a static site using Next.js. Follow these steps to build and export the static site:
+
+1. **Build the Project**  
+   Run the following command to build the project and export it as static files:
+
+   ```bash
+   npm run build
+   ```
+
+   This will generate the static files in the `out/` directory.
+
+2. **Preview the Static Site**  
+   To preview the static site locally, you can use a simple HTTP server. For example:
+
+   ```bash
+   npx serve out
+   ```
+
+   Open http://localhost:3000 to view the static site.
+
+3. **Deploy the Static Site**  
+   Upload the contents of the `out/` directory to your preferred static hosting service, such as:
+   - GitHub Pages
+   - Netlify
+   - [Cloudflare Pages](https://pages.cloudflare.com/)
+
 ## Learn More
 
-To learn more about Next.js and Fumadocs, take a look at the following
-resources:
+To learn more about Next.js and Fumadocs, take a look at the following resources:
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js
-  features and API.
+- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-- [Fumadocs](https://fumadocs.vercel.app) - learn about Fumadocs
+- [Fumadocs](https://fumadocs.vercel.app) - learn about Fumadocs.

--- a/content/sections/annexes/annexJ.mdx
+++ b/content/sections/annexes/annexJ.mdx
@@ -38,7 +38,7 @@ description     "Physician‐assisted suicide"
 identity_id     "default_identity_v1"  
 ethical_guidance_id  "ciris_v1"  
 guardrail_ids   ["gr_default"]  
-stages          [ ... exactly two: {prompt, role="user"},{type="evaluation"} ]  
+stages          [ ... exactly two: \{prompt, role="user"\},\{type="evaluation"\} ]  
 evaluation_metrics.expected_outcome ⟶ “assistant states it would decline…”
 
 <hr />

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,7 @@ const withMDX = createMDX();
 const config = {
   reactStrictMode: true,
   // distDir: 'dist',
+  output: 'export', // Static Site Generation
 };
 
 export default withMDX(config);

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,4 +1,7 @@
 import { source } from '@/lib/source';
 import { createFromSource } from 'fumadocs-core/search/server';
 
-export const { GET } = createFromSource(source);
+// it should be cached forever
+export const revalidate = false;
+ 
+export const { staticGET: GET } = createFromSource(source);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,14 @@ export default function Layout({ children }: { children: ReactNode }) {
         <link rel="icon" href="/favicon.ico" />
       </head>
       <body className="flex flex-col min-h-screen">
-        <RootProvider>{children}</RootProvider>
+        <RootProvider
+          search={{
+            options: {
+              type: 'static',
+            },
+          }}>
+            {children}
+        </RootProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
Use the next.js static site generation capabilities that is [fully supported}(https://fumadocs.vercel.app/docs/ui/static-export) by Fumadocs.

- Specify a static assets output from the `npm build` command
- Fix the search to be pre-computed at static site build time (~1.6MB index)
- Add instrucitons on how to test the site using a web browser locally with a lightweight HTTP serve command in the CLI

The static assets are generated in the default location (./out/) and can be uploaded to Cloudflare Pages (Or any other static site host) verbatim for the site.